### PR TITLE
added -e to cli script for validating schemas; expose SchemaValidator

### DIFF
--- a/python/ejsonschema/__init__.py
+++ b/python/ejsonschema/__init__.py
@@ -1,4 +1,4 @@
-from .validate import ExtValidator
+from .validate import ExtValidator, SchemaValidator
 from .schemaloader import SchemaLoader
 from jsonschema.exceptions import (ValidationError, SchemaError, 
                                    RefResolutionError)

--- a/python/ejsonschema/cli/tests/test_validatecli.py
+++ b/python/ejsonschema/cli/tests/test_validatecli.py
@@ -63,6 +63,16 @@ def test_simple_valid(tstsys):
     assert not tstsys.stderr.getvalue()
     assert exit == 0
 
+def test_load_ejs(tstsys):
+
+    app = cli.Validate("goob", tstsys.stdout, tstsys.stderr)
+    tstsys.argv[1:] = "-e {0}".format(enh_json_schema).split()
+    exit = app.execute()
+
+    assert ": valid!" in tstsys.stdout.getvalue()
+    assert not tstsys.stderr.getvalue()
+    assert exit == 0
+
 def test_simple_invalid(tstsys):
 
     baddoc = os.path.join(datadir, "invalidextension.json")


### PR DESCRIPTION
This is a follow-up to PR #1.  It imports SchemaValidator to the root module and makes it available in the CLI script via the -e option.
