### PR TITLE
allow prefix other than $ for special ejs properties

### DIFF
--- a/python/ejsonschema/cli/validate.py
+++ b/python/ejsonschema/cli/validate.py
@@ -44,6 +44,16 @@ def define_opts(progname=None):
                         dest="loadejs",
                         help="load schemas needed to validate EJS schema  "
                             +"documents (can be overridden by -L).")
+    parser.add_argument('-M', '--mongodb-safe', action='store_const',
+                        dest="epfx", const='_', default='$', 
+                        help="use a MongoDB-safe convention for special "
+                            +"validation properties, starting them with _ "
+                            +"instead of a $")
+    parser.add_argument('--val-prop-prefix', action='store', dest="epfx",
+                        metavar='PRE', type=str,
+                        help="expect the special validation properties in the "
+                            +"instance documents to start with the prefix given "
+                            +"by PRE (default: '$')")
 
     return parser
 
@@ -149,7 +159,7 @@ class Validate(Runner):
             else:
                 loader = ldr
             
-        val = ExtValidator(loader)
+        val = ExtValidator(loader, ejsprefix=self.opts.epfx)
 
         doc = None
         anyinvalid = False

--- a/python/ejsonschema/instance.py
+++ b/python/ejsonschema/instance.py
@@ -8,7 +8,8 @@ import os, json, jsonspec.pointer
 from urlparse import urlparse
 from urllib2 import urlopen
 
-EXTSCHEMAS = "$extensionSchemas"
+EXTSCHEMAS = "extensionSchemas"
+DEF_EXTSCHEMAS = "$"+EXTSCHEMAS
 
 class Instance(object):
     """
@@ -16,7 +17,8 @@ class Instance(object):
     of extended JSON schemas
     """
 
-    def __init__(self, data, srcloc=None, srcid=None, jptr="/"):
+    def __init__(self, data, srcloc=None, srcid=None, jptr="/",
+                 extschemastag=DEF_EXTSCHEMAS):
         """
         initialize the Instance wrapper
 
@@ -39,18 +41,23 @@ class Instance(object):
         :argument str jptr:    the JSON Pointer within the source file that 
                                   points to the given data.  If not given, it 
                                   can be assumed that the pointer is "/".  
+        :argument str extschemastag:  the name of the property containing the
+                                  the list of extension schema URIs that a
+                                  JSON object is compliant with (default:
+                                  "$extensionSchemas")
         """
         self.data = data
         self._srcid = srcid
         self._srcloc = srcloc
         self._ptr = jptr
+        self._exttag = extschemastag
 
         if isinstance(self.data, dict):
             if not self._srcid:
                 self._srcid = self.data.get('id')
 
     @classmethod
-    def from_location(cls, loc):
+    def from_location(cls, loc, extschemastag=DEF_EXTSCHEMAS):
         """
         Open the source location (either a file or a URL) and load its
         JSON data into an Instance instance
@@ -79,7 +86,7 @@ class Instance(object):
             # Otherwise, pass off to urllib and assume utf-8
             data = json.loads(urlopen(uri).read().decode("utf-8"))
 
-        return Instance(data, loc)
+        return Instance(data, loc, extschemastag=extschemastag)
 
 
 
@@ -176,7 +183,7 @@ class Instance(object):
         objects (including the root object, if applicable) that contains 
         the "$exensionSchemas" property.  
         """
-        return self.find_obj_by_prop(EXTSCHEMAS)
+        return self.find_obj_by_prop(self._exttag)
 
     def extract(self, jptr):
         """

--- a/python/ejsonschema/tests/test_instance.py
+++ b/python/ejsonschema/tests/test_instance.py
@@ -45,17 +45,17 @@ class TestInstance(object):
         assert "metals" in found[0][1]
         assert len(found[0][1]) >= 5
 
-        found = inst.find_data_by_name(instance.EXTSCHEMAS)
+        found = inst.find_data_by_name(instance.DEF_EXTSCHEMAS)
         assert len(found) == 2
         assert len(found[0]) == 2
 
         found = dict(found)
-        path = "/"+instance.EXTSCHEMAS
+        path = "/"+instance.DEF_EXTSCHEMAS
         assert path in found
         assert isinstance(found[path], list)
         assert "ms:Database" in found[path]
         assert len(found[path]) == 1
-        path = "/applicability/0/"+instance.EXTSCHEMAS
+        path = "/applicability/0/"+instance.DEF_EXTSCHEMAS
         assert isinstance(found[path], list)
         assert "ms:MaterialScience" in found[path]
         assert len(found[path]) == 1
@@ -74,7 +74,7 @@ class TestInstance(object):
         assert "subject" in found[0][1]
         assert len(found[0][1]['subject']) >= 5
 
-        found = inst.find_obj_by_prop(instance.EXTSCHEMAS)
+        found = inst.find_obj_by_prop(instance.DEF_EXTSCHEMAS)
         assert len(found) == 2
         assert len(found[0]) == 2
 
@@ -82,14 +82,14 @@ class TestInstance(object):
         path = "/"
         assert path in found
         assert isinstance(found[path], dict)
-        assert instance.EXTSCHEMAS in found[path]
-        assert len(found[path][instance.EXTSCHEMAS]) == 1
-        assert "ms:Database" in found[path][instance.EXTSCHEMAS]
+        assert instance.DEF_EXTSCHEMAS in found[path]
+        assert len(found[path][instance.DEF_EXTSCHEMAS]) == 1
+        assert "ms:Database" in found[path][instance.DEF_EXTSCHEMAS]
         path = "/applicability/0"
         assert isinstance(found[path], dict)
-        assert instance.EXTSCHEMAS in found[path]
-        assert "ms:MaterialScience" in found[path][instance.EXTSCHEMAS]
-        assert len(found[path][instance.EXTSCHEMAS]) == 1
+        assert instance.DEF_EXTSCHEMAS in found[path]
+        assert "ms:MaterialScience" in found[path][instance.DEF_EXTSCHEMAS]
+        assert len(found[path][instance.DEF_EXTSCHEMAS]) == 1
 
     def test_find_extend_objs(self):
         inst = instance.Instance.from_location(exfile)
@@ -100,14 +100,14 @@ class TestInstance(object):
         path = "/"
         assert path in found
         assert isinstance(found[path], dict)
-        assert instance.EXTSCHEMAS in found[path]
-        assert len(found[path][instance.EXTSCHEMAS]) == 1
-        assert "ms:Database" in found[path][instance.EXTSCHEMAS]
+        assert instance.DEF_EXTSCHEMAS in found[path]
+        assert len(found[path][instance.DEF_EXTSCHEMAS]) == 1
+        assert "ms:Database" in found[path][instance.DEF_EXTSCHEMAS]
         path = "/applicability/0"
         assert isinstance(found[path], dict)
-        assert instance.EXTSCHEMAS in found[path]
-        assert "ms:MaterialScience" in found[path][instance.EXTSCHEMAS]
-        assert len(found[path][instance.EXTSCHEMAS]) == 1
+        assert instance.DEF_EXTSCHEMAS in found[path]
+        assert "ms:MaterialScience" in found[path][instance.DEF_EXTSCHEMAS]
+        assert len(found[path][instance.DEF_EXTSCHEMAS]) == 1
 
     def test_extract(self):
         inst = instance.Instance.from_location(exfile)

--- a/python/ejsonschema/tests/test_validate.py
+++ b/python/ejsonschema/tests/test_validate.py
@@ -7,6 +7,7 @@ from cStringIO import StringIO
 from . import Tempfiles
 import ejsonschema.validate as val
 import ejsonschema.schemaloader as loader
+from ejsonschema.instance import DEF_EXTSCHEMAS
 
 from .config import schema_dir as schemadir, data_dir as datadir, \
                     examples_dir as exdir
@@ -100,7 +101,7 @@ class TestExtValidator(object):
         # these should not
         with open(probfile) as fd:
             inst = json.load(fd)
-        errs = validator.validate_against(inst, inst[val.EXTSCHEMAS][0], True)
+        errs = validator.validate_against(inst, inst[DEF_EXTSCHEMAS][0], True)
         assert len(list(filter(lambda e: isinstance(e, val.ValidationError),errs))) > 0
 
         with pytest.raises(val.ValidationError):


### PR DESCRIPTION
MongoDB does not allow loading documents that contain properties that begin with `$`, so I added a parameter to the `ExtValidator` class that allows one to assume a different prefix for the special validation properties (namely, `*schema` and `*extensionSchemas`) that the validator will look for in instances documents.  A similar change was needed in the `Instance` class constructor.  Access to this feature was added to CLI script, `validate`, via the `--val-prop-prefix` and `-M` options:  the former allows one to set an arbitrary prefix, while the latter sets it to `_` (an underscore), a convention intended for use with MongoDB.  