### PR TITLE
Display available schemas when needed schema is missing

### DIFF
--- a/python/ejsonschema/cli/tests/test_validatecli.py
+++ b/python/ejsonschema/cli/tests/test_validatecli.py
@@ -91,7 +91,7 @@ def test_cant_resolve(tstsys):
     tstsys.argv[1:] = "{0}".format(enh_json_schema).split()
     exit = app.execute()
 
-    assert "Unable to resolve reference in schema" in tstsys.stderr.getvalue()
+    assert "Unable to find schema document" in tstsys.stderr.getvalue()
     assert ": not valid" in tstsys.stdout.getvalue()
     assert exit == 2
 
@@ -123,7 +123,7 @@ def test_strict(tstsys):
     tstsys.argv[1:] = "-L {0} -C {1}".format(exdir, ipr_ex).split()
     exit = app.execute()
 
-    assert "Unable to resolve reference in schema" in tstsys.stderr.getvalue()
+    assert "Unable to find schema document" in tstsys.stderr.getvalue()
     assert ": not valid" in tstsys.stdout.getvalue()
     assert exit == 2
 
@@ -133,7 +133,7 @@ def test_schema_override(tstsys):
     tstsys.argv[1:] = "-L {0} -S urn:gurn {1}".format(exdir, ipr_ex).split()
     exit = app.execute()
 
-    assert "Unable to resolve reference in schema" in tstsys.stderr.getvalue()
+    assert "Unable to find schema document" in tstsys.stderr.getvalue()
     assert ": not valid" in tstsys.stdout.getvalue()
     assert exit == 2
     

--- a/python/ejsonschema/validate.py
+++ b/python/ejsonschema/validate.py
@@ -193,8 +193,8 @@ class ExtValidator(object):
                     try:
                         schema = self._loader(urib)
                     except KeyError, e:
-                        ex = RefResolutionError(
-                                "Unable find schema document for " + urib)
+                        ex = MissingSchemaDocument(
+                                "Unable to find schema document for " + urib)
                         if strict:
                             out.append(ex)
                         continue
@@ -265,6 +265,12 @@ def SchemaValidator():
     files pre-cached.  
     """
     return ExtValidator(loader.schemaLoader_for_schemas())
+
+class MissingSchemaDocument(RefResolutionError):
+    """
+    An error indicating that a needed schema document cannot be loaded.
+    """
+    pass
 
 
 from jsonschema._utils import format_as_index as format_path, \


### PR DESCRIPTION
When using the command-line tool, `validate`, and a needed schema document cannot be found, it's often unclear why.  It could be:
- the schema document is not in the schema cache nor available on-line
- there is a typo in the schema id in the instance document
- the schema is in the cache but has a format error, and therefore was not loaded
When a schema document cannot be found, it can help which problem is the source of the issue if a list of the IDs for schemas that are available is listed.

This PR adds a `-v` option to the command-line tool, `validate`, which will list the available schemas when a schema document cannot be found.
