### PR TITLE
changing URI for ejsonschema schema to based at data.nist.gov 

### DIFF
--- a/python/ejsonschema/tests/data/invalidextension.json
+++ b/python/ejsonschema/tests/data/invalidextension.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "$extensionSchemas": ["https://www.nist.gov/od/dm/enhanced-json-schema/v0.1"],
+  "$extensionSchemas": ["https://data.nist.gov/od/dm/enhanced-json-schema/v0.1"],
   "id": "http://mgi.nist.gov/json/res-md/v1.0wd",
   "title": "Resource metadata type library",
   "description": "a library of schemas for describing resources in a data federation",

--- a/python/ejsonschema/tests/data/noid_schema.json
+++ b/python/ejsonschema/tests/data/noid_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema",
-  "$extensionSchemas": ["https://www.nist.gov/od/dm/enhanced-json-schema/v0.1"],
+  "$extensionSchemas": ["https://data.nist.gov/od/dm/enhanced-json-schema/v0.1"],
   "patch": "0",
   "title": "Registry Resource record schema",
   "description": "a resource record format for use in a registry",

--- a/python/ejsonschema/tests/test_schemaloader.py
+++ b/python/ejsonschema/tests/test_schemaloader.py
@@ -131,7 +131,7 @@ class TestSchemaLoader(object):
 
 def test_schemaLoader_for_schemas():
     ldr = loader.schemaLoader_for_schemas()
-    loc = ldr.locate("https://www.nist.gov/od/dm/enhanced-json-schema/v0.1")
+    loc = ldr.locate("https://data.nist.gov/od/dm/enhanced-json-schema/v0.1")
     assert os.path.basename(loc) == "enhanced-json-schema.json"
     assert os.path.exists(loc)
     loc = ldr.locate("http://json-schema.org/draft-04/schema")
@@ -155,7 +155,7 @@ class TestSchemaHandler(object):
 
     def test_compat(self):
         ldr = loader.SchemaLoader(locs)
-        ldr.add_location("https://www.nist.gov/od/dm/enhanced-json-schema/v0.1", 
+        ldr.add_location("https://data.nist.gov/od/dm/enhanced-json-schema/v0.1", 
                          schemafile)
         hdlr = loader.SchemaHandler(ldr)
 
@@ -168,11 +168,11 @@ class TestSchemaHandler(object):
         assert hdlr["http"] is ldr
         assert hdlr["ftp"] is ldr  # not strict
 
-        schema = hdlr["https"]("https://www.nist.gov/od/dm/enhanced-json-schema/v0.1")
+        schema = hdlr["https"]("https://data.nist.gov/od/dm/enhanced-json-schema/v0.1")
         assert isinstance(schema, dict)
         assert "$schema" in schema
         assert "id" in schema
-        assert schema["id"] == "https://www.nist.gov/od/dm/enhanced-json-schema/v0.1"
+        assert schema["id"] == "https://data.nist.gov/od/dm/enhanced-json-schema/v0.1"
 
     def test_strict(self):
         ldr = loader.SchemaLoader(locs)

--- a/python/ejsonschema/tests/test_validateschema.py
+++ b/python/ejsonschema/tests/test_validateschema.py
@@ -20,7 +20,7 @@ def validator(request):
 
 schemashell = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$extensionSchemas": [ "https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#" ],
+    "$extensionSchemas": [ "https://data.nist.gov/od/dm/enhanced-json-schema/v0.1#" ],
     "id": "urn:goob"
 }
 
@@ -30,7 +30,7 @@ def test_NotesType(validator):
     schema["type"] = "object"
     schema["properties"] = {
         "sayings": {
-            "$ref": "https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#/definitions/Notes"
+            "$ref": "https://data.nist.gov/od/dm/enhanced-json-schema/v0.1#/definitions/Notes"
         }
     }
     validator.load_schema(schema)
@@ -46,7 +46,7 @@ def test_NotesType(validator):
     
 def test_DocumentationType(validator):
     schema = schemashell.copy()
-    schema['$ref'] = "https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#/definitions/Documentation"
+    schema['$ref'] = "https://data.nist.gov/od/dm/enhanced-json-schema/v0.1#/definitions/Documentation"
     schema['id'] = "urn:doc"
     validator.load_schema(schema)
 
@@ -77,10 +77,26 @@ def test_DocumentationType(validator):
     inst["description"] = "the def"
     assert len(validator.validate_against(inst, [schema['id']])) == 0
 
+def test_oldschemauri(validator):
+    """
+    test that we can validate schemas that reference deprecated URIs for the 
+    ejsonschema schema.  As long as the deprecated URI has an entry in the 
+    [schema_dir]/schemaLocation.json file, it should work.  
+    """
+    schema = schemashell.copy()
+    schema["$extensionSchemas"] = [ "https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#" ]
+    schema['$ref'] = "https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#/definitions/Documentation"
+    schema['id'] = "urn:doc"
+
+    validator.validate(schema, strict=True)
+    
+    schema["$extensionSchemas"] = [ "https://goober.nist.gov/od/dm/enhanced-json-schema/v0.1#" ]
+    with pytest.raises(val.MissingSchemaDocument):
+        validator.validate(schema, strict=True)
     
 def test_PropDocumentationType(validator):
     schema = schemashell.copy()
-    schema['$ref'] = "https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#/definitions/PropertyDocumentation"
+    schema['$ref'] = "https://data.nist.gov/od/dm/enhanced-json-schema/v0.1#/definitions/PropertyDocumentation"
     schema['id'] = "urn:propdoc"
     validator.load_schema(schema)
 

--- a/python/ejsonschema/validate.py
+++ b/python/ejsonschema/validate.py
@@ -16,7 +16,8 @@ SCHEMATAG = "schema"
 
 # These are URIs that identify versions of the JSON Enhanced Schema schem
 EXTSCHEMA_URIS = [ "http://mgi.nist.gov/mgi-json-schema/v0.1",
-                   "https://www.nist.gov/od/dm/enhanced-json-schema/v0.1" ]
+                   "https://www.nist.gov/od/dm/enhanced-json-schema/v0.1",
+                   "https://data.nist.gov/od/dm/enhanced-json-schema/v0.1" ]
 
 class ExtValidator(object):
     """

--- a/schemas/enhanced-json-schema.json
+++ b/schemas/enhanced-json-schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$extensionSchemas": [ "https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#" ],
-    "id": "https://www.nist.gov/od/dm/enhanced-json-schema/v0.1",
+    "$extensionSchemas": [ "https://data.nist.gov/od/dm/enhanced-json-schema/v0.1#" ],
+    "id": "https://data.nist.gov/od/dm/enhanced-json-schema/v0.1",
     "title": "Enhanced JSON Schema supporting extensions validation",
     "description": "An extension of json-schema that defines additional non-validating properties that support richer annotation of a schema and interpretation of instances",
     "definitions": {

--- a/schemas/schemaLocation.json
+++ b/schemas/schemaLocation.json
@@ -1,5 +1,7 @@
 {
     "http://json-schema.org/draft-04/schema#": "json-schema.json",
+    "https://data.nist.gov/od/dm/enhanced-json-schema/v0.1#":
+         "enhanced-json-schema.json",
     "https://www.nist.gov/od/dm/enhanced-json-schema/v0.1#":
          "enhanced-json-schema.json"
 }


### PR DESCRIPTION
In anticipation of hosting schema at https://data.nist.gov/od/dm, I'm officially changing the ejsonschema's schema URI to that location.  This PR also adds a test that test to make sure old URIs can still work; all URIs to be recognized as ejsonschema should have an entry in the schemaLocation.json file used by the validator.
