### PR TITLE
Provide support for python 3.9, 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: python
 
+dist:
+  - jammy
 python:
-  - "2.7"
   - "3.8"
   - "3.9"
   - "3.10"
+
+jobs:
+  include:
+    - dist: bionic
+      pyton: "2.7"
 
 os:
     - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 
 python:
   - "2.7"
-  - "3.5"
-  - "3.6"
   - "3.8"
+  - "3.9"
+  - "3.10"
 
 os:
     - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 jobs:
   include:
     - dist: bionic
-      pyton: "2.7"
+      python: "2.7"
 
 os:
     - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,12 @@
+os: linux
+dist: focal
+arch: amd64
 language: python
-
-dist:
-  - jammy
 python:
+  - "2.7"
   - "3.8"
   - "3.9"
   - "3.10"
-
-jobs:
-  include:
-    - dist: bionic
-      python: "2.7"
-
-os:
-    - linux
 
 env:
     global:

--- a/pip-requirements
+++ b/pip-requirements
@@ -1,5 +1,6 @@
-jsonschema>=2.5.0, <3.0.0
+jsonschema<2.5.0
 json-spec>=0.9.16
 requests
 pytest
 coverage
+six

--- a/python/ejsonschema/schemaloader.py
+++ b/python/ejsonschema/schemaloader.py
@@ -5,7 +5,10 @@ cached on local disk.
 from __future__ import with_statement
 import six
 import sys, os, json, errno
-from collections.abc import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 try:
     from urllib.parse import urlparse
     from urllib.request import urlopen

--- a/python/ejsonschema/schemaloader.py
+++ b/python/ejsonschema/schemaloader.py
@@ -5,7 +5,7 @@ cached on local disk.
 from __future__ import with_statement
 import six
 import sys, os, json, errno
-from collections import Mapping
+from collections.abc import Mapping
 try:
     from urllib.parse import urlparse
     from urllib.request import urlopen

--- a/python/ejsonschema/validate.py
+++ b/python/ejsonschema/validate.py
@@ -4,7 +4,7 @@ extended json-schema tags.
 """
 from __future__ import with_statement
 import sys, os, json
-from collections import Mapping
+from collections.abc import Mapping
 try:
     # python 3
     import urllib.parse as urlparse

--- a/python/ejsonschema/validate.py
+++ b/python/ejsonschema/validate.py
@@ -4,7 +4,10 @@ extended json-schema tags.
 """
 from __future__ import with_statement
 import sys, os, json
-from collections.abc import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 try:
     # python 3
     import urllib.parse as urlparse


### PR DESCRIPTION
This mainly involved providing a 2.7 compatible way to import Mapping.  Travis config file updated to test.  (Dropped testing on python 3.5-3.7.)
